### PR TITLE
Copy to the Request to the Response instance.

### DIFF
--- a/src/HttpClient.Helpers/FakeMessageHandler.cs
+++ b/src/HttpClient.Helpers/FakeMessageHandler.cs
@@ -79,8 +79,27 @@ namespace WorldDomination.Net.Http
             // Increment the number of times this option had been 'called'.
             IncrementCalls(expectedOption);
 
-            tcs.SetResult(expectedOption.HttpResponseMessage);
+            var result = CreateResponseMessageForRequest(request, expectedOption.HttpResponseMessage);
+
+            tcs.SetResult(result);
             return tcs.Task;
+        }
+
+        private static HttpResponseMessage CreateResponseMessageForRequest(HttpRequestMessage request, HttpResponseMessage templateResponse)
+        {
+            var response = new HttpResponseMessage(templateResponse.StatusCode)
+            {
+                Content = templateResponse.Content,
+                RequestMessage = request,
+                Version = templateResponse.Version
+            };
+
+            foreach (var header in templateResponse.Headers)
+            {
+                response.Headers.Add(header.Key, header.Value);
+            }
+
+            return response;
         }
 
         /// <summary>


### PR DESCRIPTION
Before being returned, the HttpResponseMessage available in the selected HttpMessageOptions is cloned.
The current request is then attached to the cloned request.

This allows scenarios like `var requestUri = response.Request.RequestUri` during the test phase.