### PR TITLE
🚀 Updated Test application (netcore31) and AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,7 @@
-
-#
-# Current setup:
-# - All development is done in a fork.
-# - Pull requests are merged into master and it auto publishes to the myget pre-release 'pk-development' feed.
-# - To publish a live NuGet package, create a tag on master branch.
-#
-
 version: '{build}.0.0-dev'
-configuration: Release
-os: Visual Studio 2017
+image: Ubuntu
 pull_requests:
   do_not_increment_build_number: true
-environment:
-  project_name: HttpClient.Helpers
-  library_project_file: 'src\%project_name%\%project_name%.csproj'
-  tests_project_file: 'tests\%project_name%.Tests\%project_name%.Tests.csproj'
 
 # Override the 'version' if this is a GH-tag-commit -or- this is a custom branch (i.e not 'master').
 init:
@@ -25,17 +12,51 @@ init:
           Update-AppveyorBuild -Version "$env:APPVEYOR_REPO_TAG_NAME"
       }
       iex ((new-object net.webclient).DownloadString('https://gist.githubusercontent.com/PureKrome/0f79e25693d574807939/raw/f5b40256fc2ca77d49f1c7773d28406152544c1e/appveyor-build-info.ps'))
-                                       
+
+
+matrix:
+  fast_finish: true
+
+configuration:
+  - Debug
+  - Release
+
 before_build:
+  # Display .NET Core version
   - dotnet --info
-  - dotnet restore 
 
 build_script:
-  - dotnet build -c %CONFIGURATION% /p:Version=%APPVEYOR_BUILD_VERSION%
+  - dotnet restore --verbosity quiet
+  - ps: dotnet build -c $env:CONFIGURATION -v minimal /p:Version=$env:APPVEYOR_BUILD_VERSION --no-restore
 
 test_script:
-  - dotnet test %tests_project_file% -c %CONFIGURATION% -v normal --no-build
-  - dotnet pack %library_project_file% -c %CONFIGURATION% /p:Version=%APPVEYOR_BUILD_VERSION% --no-build
+  - ps: |
+      if ($env:CONFIGURATION -eq 'Debug')
+      {
+          dotnet test -c $env:CONFIGURATION -v minimal --no-build --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory './CodeCoverageResults'
+      }
+      else
+      {
+          dotnet test -c $env:CONFIGURATION -v minimal --no-build
+      }
+
+
+# We only:
+#   - Send DEBUG results up to codecov.
+#   - Pack for RELEASE only.
+after_test:
+  - ps: |
+      if ($env:CONFIGURATION -eq 'Debug')
+      {
+          # Currently, the bash script version is better than the .exe version.
+          Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
+          bash codecov.sh -s './CodeCoverageResults/' -f '*.xml' -Z
+      }
+      
+      if ($env:CONFIGURATION -eq 'Release')
+      {
+          dotnet pack -c $env:CONFIGURATION --include-symbols -p:SymbolPackageFormat=snupkg /p:Version=$env:APPVEYOR_BUILD_VERSION --no-build
+      }
 
 artifacts:
   - path: '**\*.nupkg'
@@ -44,6 +65,7 @@ artifacts:
   - path: '**\*.snupkg'
     name: nuget-symbols
     type: NuGetPackage
+
 
 deploy:
 
@@ -56,6 +78,7 @@ deploy:
     artifact: nuget-packages
     on:
       appveyor_repo_tag: false
+
   - provider: NuGet
     api_key:
       secure: jfcUvHZhgnUboplqTBDWr8mG5PIlrgBv5TA2fhhop4ZSiDxskyy+RtYyeHoduJFR

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Exclude>[*.Tests]*</Exclude> <!-- [Assembly-Filter]Type-Filter -->
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings> 

--- a/tests/HttpClient.Helpers.Tests/HttpClient.Helpers.Tests.csproj
+++ b/tests/HttpClient.Helpers.Tests/HttpClient.Helpers.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,10 +22,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\HttpClient.Helpers\HttpClient.Helpers.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/tests/HttpClient.Helpers.Tests/HttpClient.Helpers.Tests.csproj
+++ b/tests/HttpClient.Helpers.Tests/HttpClient.Helpers.Tests.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit.core" Version="2.4.1" />


### PR DESCRIPTION
- NetCore 3.1 is the current LTS
- AppVeyor now does `debug` and `release` builds + codecov + 🐧 Ubuntu.